### PR TITLE
point blocking_queue dependency to hex

### DIFF
--- a/apps/twitter/mix.exs
+++ b/apps/twitter/mix.exs
@@ -36,7 +36,7 @@ defmodule Twitter.Mixfile do
   defp deps do
     [{:oauth, github: "tim/erlang-oauth"},
      {:extwitter, "~> 0.2"},
-     {:blocking_queue, git: "/Users/jkain/Documents/Projects/elixir/blocking_queue/", branch: "name"},
+     {:blocking_queue, "~> 1.0.0"},
      {:exactor,  "~> 2.2"}]
   end
 end

--- a/apps/unshortening_pool/mix.exs
+++ b/apps/unshortening_pool/mix.exs
@@ -37,7 +37,7 @@ defmodule UnshorteningPool.Mixfile do
     [
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
       {:httpotion, "~> 2.1.0"},
-      {:blocking_queue, git: "/Users/jkain/Documents/Projects/elixir/blocking_queue/", branch: "name"},
+      {:blocking_queue, "~> 1.0.0"},
       {:poolboy,  github: "devinus/poolboy" },
       {:exactor,  "~> 2.2"}
    ]


### PR DESCRIPTION
The blocking_queue dependency pointed to a local directory on joekain's machine. Fix it to point to the hex package so that mix deps.get finds it.
